### PR TITLE
Changes to avoid getting notices and deprecated errors

### DIFF
--- a/pub/detail.php
+++ b/pub/detail.php
@@ -115,7 +115,7 @@
                             <td><b><?php echo $param["name"] ?> </b></td>
                             <td><?php echo $param["description"] ; ?>  </td>
                             <td><?php if ($param["optional"]) { echo "True" ; } ?></td>
-                            <td><?php if ($param["default"]) { echo $param["default"] ; } ?></td>
+                            <td><?php if (!empty($param["default"])) { echo $param["default"] ; } ?></td>
                         </tr>
                         <?php } ?>
                     </tbody>

--- a/pub/settings.ini
+++ b/pub/settings.ini
@@ -1,4 +1,4 @@
-# for relative path - yaml index location is relative to pub dir
-# unix machines - beware of cases - better use all small cases
+;for relative path - yaml index location is relative to pub dir
+;unix machines - beware of cases - better use all small cases
 yaml.index=index.yaml
 brand.name=Yuktix


### PR DESCRIPTION
I was getting:

( ! ) Deprecated: Comments starting with '#' are deprecated in settings.ini on line 1 in /var/www/y1000/api-doc/pub/index.php on line 8
( ! ) Deprecated: Comments starting with '#' are deprecated in settings.ini on line 2 in /var/www/y1000/api-doc/pub/index.php on line 8

Fixed replacing the "#" comments for ";", as expected in a ini file
